### PR TITLE
Add support for page-breaks to be inserted before elements that would otherwise intersect them

### DIFF
--- a/src/plugin/pagebreaks.js
+++ b/src/plugin/pagebreaks.js
@@ -14,5 +14,22 @@ Worker.prototype.toContainer = function toContainer() {
       var clientRect = el.getBoundingClientRect();
       el.style.height = pxPageHeight - (clientRect.top % pxPageHeight) + 'px';
     }, this);
+
+    // Shim some padding before elements that would otherwise intersect a page break
+    pageBreaks = this.prop.container.querySelectorAll('.html2pdf__avoid-page-break');
+    Array.prototype.forEach.call(pageBreaks, function pageBreak_loop(el) {
+      var clientRect = el.getBoundingClientRect();
+      var startPage = Math.floor(clientRect.top / pxPageHeight);
+      var endPage = Math.floor(clientRect.bottom / pxPageHeight);
+      if (endPage > startPage && Math.abs(endPage - startPage) === 1) {
+        // the element is straddling a single page break.
+        // insert a padding div to push the element to the next page.
+        var currentDocHeight = (startPage + 1) * pxPageHeight;
+        var pad = document.createElement('div');
+        pad.style.display = 'block';
+        pad.style.height = currentDocHeight - clientRect.top % currentDocHeight + 'px';
+        el.parentNode.insertBefore(pad, el);
+      }
+    }, this);
   });
 };


### PR DESCRIPTION
Any element with class 'html2pdf__avoid-page-break' that intersects a page-break will instead be pushed to the next page by inserting a shim div before it.
Elements with the class that span more than a full page are ignored.
Confirmed working on latest source for documents with multiple pages.