### PR TITLE
Allow html2canvas options to be set across multiple .set() calls

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -307,6 +307,10 @@ Worker.prototype.set = function set(opt) {
             return function set_jsPDF() { this.opt.jsPDF = opt.jsPDF; return this.setPageSize(); }
           case 'pageSize':
             return this.setPageSize.bind(this, opt.pageSize);
+          case 'html2canvas':
+            return Object.keys(opt[key] || {}).map(function (h2cKey) {
+              return this.opt['html2canvas'][h2cKey] = opt[key][h2cKey];
+            });
           default:
             // Set any other properties in opt.
             return function set_opt() { this.opt[key] = opt[key] };

--- a/src/worker.js
+++ b/src/worker.js
@@ -308,9 +308,11 @@ Worker.prototype.set = function set(opt) {
           case 'pageSize':
             return this.setPageSize.bind(this, opt.pageSize);
           case 'html2canvas':
-            return Object.keys(opt[key] || {}).map(function (h2cKey) {
-              return this.opt['html2canvas'][h2cKey] = opt[key][h2cKey];
-            });
+            return function set_html2canvas() {
+              Object.keys(opt.html2canvas || {}).map(function (key) {
+                return this.opt.html2canvas[key] = opt.html2canvas[key];
+              }, this);
+            };
           default:
             // Set any other properties in opt.
             return function set_opt() { this.opt[key] = opt[key] };


### PR DESCRIPTION
I am using Froala that allows one to save the editors contents as a PDF. It uses `html2pdf.js` to do this, and allows me to pass in the html2pdf function to use. I wanted to set some extra config (specifically `html2canvas`) but since Froala also sets the `html2canvas` key via `.set()`, my configuration got blown away.

This PR allows one to set `html2canvas` options across multiple `set()` calls by only setting the individual keys rather than replacing the whole object.