### PR TITLE
containerCSS backgroundColor: 'transparent'

### DIFF
--- a/dist/html2pdf.bundle.js
+++ b/dist/html2pdf.bundle.js
@@ -8676,7 +8676,7 @@ Worker.prototype.toContainer = function toContainer() {
     var containerCSS = {
       position: 'absolute', width: this.prop.pageSize.inner.width + this.prop.pageSize.unit,
       left: 0, right: 0, top: 0, height: 'auto', margin: 'auto',
-      backgroundColor: 'white'
+      backgroundColor: this.opt.backgroundColor || 'transparent'
     };
 
     // Set the overlay to hidden (could be changed in the future to provide a print preview).


### PR DESCRIPTION
A white backgroundColor overwrites the backgroundColor of html2canvas. changed to transparent and added an opt.backgroundColor as well (optional)