### PR TITLE
feat: ability to force add current page

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,37 @@ These options are limited to the available settings for [HTMLCanvasElement.toDat
 
 The Worker object returned by `html2pdf()` has a built-in progress-tracking mechanism. It will be updated to allow a progress callback that will be called with each update, however it is currently a work-in-progress.
 
+## Multiple pages
+
+The `html2pdf` would failed with too many pages, because of the canvas limitations.
+For more information check this issue [#19](https://github.com/eKoopmans/html2pdf.js/issues/19)
+
+You can split your page into smaller chunks and individually adding them into the PDF.
+
+```js
+const pages = Array.from(document.querySelectorAll('.page'));
+const opt = {};
+
+let worker = html2pdf()
+  .from(pages[0])
+  .set(opt)
+  .toPdf();
+
+pages.forEach(function(page, idx) {
+  worker = worker
+    .get('pdf')
+    .then(pdf => {
+      if (!idx) return;
+      pdf.addPage();
+    })
+    .from(page)
+    .toContainer()
+    .toCanvas()
+    .toPdf(idx + 1);
+});
+worker = worker.save();
+```
+
 ## Dependencies
 
 html2pdf.js depends on the external packages [html2canvas](https://github.com/niklasvh/html2canvas), [jsPDF](https://github.com/MrRio/jsPDF), and [es6-promise](https://github.com/stefanpenner/es6-promise). These dependencies are automatically loaded when using NPM or the bundled package.

--- a/src/plugin/hyperlinks.js
+++ b/src/plugin/hyperlinks.js
@@ -40,13 +40,13 @@ Worker.prototype.toContainer = function toContainer() {
   });
 };
 
-Worker.prototype.toPdf = function toPdf() {
+Worker.prototype.toPdf = function toPdf(forcePage) {
   return orig.toPdf.call(this).then(function toPdf_hyperlink() {
     // Add hyperlinks if the option is enabled.
     if (this.opt.enableLinks) {
       // Attach each anchor tag based on info from toContainer().
       linkInfo.forEach(function(l) {
-        this.prop.pdf.setPage(l.page);
+        this.prop.pdf.setPage(forcePage || l.page);
         this.prop.pdf.link(l.left, l.top, l.clientRect.width, l.clientRect.height,
                            { url: l.link.href });
       }, this);


### PR DESCRIPTION
## Motivation
When generating a pdf file with more than many multiple pages, it does not create successfully, due to canvas size limitations.  We can generate each page individually then bind it to the pdf. The problem with this technique, that the clickable links will work only on the first page, because of the way the current page being calculated.

## Solution
In my __PR__ I introduce a way to force the current page which is currently being generating.
You can then use the code as follows:
```js
const pages = Array.from(document.querySelectorAll('.page'));
const opt = {};

let worker = html2pdf()
  .from(pages[0])
  .set(opt)
  .toPdf();

pages.forEach(function(page, idx) {
  worker = worker
    .get('pdf')
    .then(pdf => {
      if (!idx) return;
      pdf.addPage();
    })
    .from(page)
    .toContainer()
    .toCanvas()
    .toPdf(idx + 1); // <== Explicitly set the page number
});
worker = worker.save();
``