### PR TITLE
To be able to use the many pages workaround we need to pass in pageNr…

### DIFF
--- a/src/plugin/hyperlinks.js
+++ b/src/plugin/hyperlinks.js
@@ -10,7 +10,7 @@ var orig = {
   toPdf: Worker.prototype.toPdf,
 };
 
-Worker.prototype.toContainer = function toContainer() {
+Worker.prototype.toContainer = function toContainer(pageNumber) {
   return orig.toContainer.call(this).then(function toContainer_hyperlink() {
     // Retrieve hyperlink info if the option is enabled.
     if (this.opt.enableLinks) {
@@ -29,7 +29,7 @@ Worker.prototype.toContainer = function toContainer() {
           clientRect.left -= containerRect.left;
           clientRect.top -= containerRect.top;
 
-          var page = Math.floor(clientRect.top / this.prop.pageSize.inner.height) + 1;
+          var page = pageNumber || Math.floor(clientRect.top / this.prop.pageSize.inner.height) + 1;
           var top = this.opt.margin[0] + clientRect.top % this.prop.pageSize.inner.height;
           var left = this.opt.margin[1] + clientRect.left;
 


### PR DESCRIPTION
https://github.com/eKoopmans/html2pdf.js/issues/19#issuecomment-484240946

Then you can use the code snippet below to make links work in multipages pdf

```
  const saveMultiPagePdf = (opt) => {
    // To avoid blank pages in the pdf we need to manually add the divs
    // See issue https://github.com/eKoopmans/html2pdf.js/issues/19
    const html2pdf = require('html2pdf.js');

    const domElementCollection = pageClassNameId
      ? document.getElementsByClassName(pageClassNameId)
      : pdfContent.current.children;

    const domPages = [...domElementCollection].map((htmlElement) => {
      return htmlElement.outerHTML;
    });

    let worker = html2pdf()
      .from(domPages[0])
      .set(opt)
      .toContainer(1)
      .toPdf();

    domPages.slice(1).forEach((page, index) => {
      worker = worker
        .get('pdf')
        .then((pdf) => {
          pdf.addPage();
        })
        .from(page)
        .set(opt)
        .toContainer(index + 2)
        .toCanvas()
        .toPdf();
    });

    return worker.save();
  };
```