### PR TITLE
Fix pagebreaks bug while first line clientRect.top less than 0

### DIFF
--- a/src/plugin/pagebreaks.js
+++ b/src/plugin/pagebreaks.js
@@ -114,9 +114,12 @@ Worker.prototype.toContainer = function toContainer() {
 
       // Before: Create a padding div to push the element to the next page.
       if (rules.before) {
+        var height = clientRect.top >= 0
+                      ? pxPageHeight - (clientRect.top % pxPageHeight)
+                      : Math.abs(clientRect.top);
         var pad = createElement('div', {style: {
           display: 'block',
-          height: pxPageHeight - (clientRect.top % pxPageHeight) + 'px'
+          height: height + 'px'
         }});
         el.parentNode.insertBefore(pad, el);
       }


### PR DESCRIPTION
If mode include "avoid-all", and first line clientRect.top less than 0, pagebreaks.js will create full page div, make first page empty

**test case**
```
// pagebreaks.html
  ...
    <div id="root">
      <p style='margin-top: -10px'>First line</p>
  ...
```