### PR TITLE
fix: set jspdf to 1.4.1 to avoid semver resolution of newer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "es6-promise": "^4.2.5",
     "html2canvas": "^1.0.0-alpha.12",
-    "jspdf": "^1.4.1"
+    "jspdf": "1.4.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",


### PR DESCRIPTION
Synopsis:
- `jspdf` version in `package.json` is specified as `^1.4.1`, `1.4.1` explicitly is locked in `package-lock.json` so this version is used for development.
- Because of the way semver works, when installing `html2pdf.js` as a consumer npm is not resolving `1.4.1` it's resolving the latest minor version `1.5.3`
- `jspdf`@1.5.3 does something really nasty: imports a dependency directly from github.

Evidence:
- https://github.com/MrRio/jsPDF/blob/v1.5.3/package.json#L27

Problem:
- Personal: I'm not comfortable with this and I'm sure many others feel the same
- My org: For security reasons, our CI does not allow dependencies that aren't proxied through our private registry
- General: This makes the library not proxiable/replicatable in a private npm registry because the dependency exists outside of npm, which is a problem for more than just my org

Solution:
`jspdf` have already remedied this problem in `2.x.x`, but rather than take on the cost of any potential breaking changes they've introduced I'm proposing we simply lock the version to `1.4.1`. This way the `jspdf` version consumers use matches the one developers of this library use.