### PR TITLE
Fix set-pageSize behaviour

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -297,22 +297,22 @@ Worker.prototype.set = function set(opt) {
 
   // Build an array of setter functions to queue.
   var fns = Object.keys(opt || {}).map(function (key) {
-      if (key in Worker.template.prop) {
-        // Set pre-defined properties.
-        return function set_prop() { this.prop[key] = opt[key]; }
-      } else {
-        switch (key) {
-          case 'margin':
-            return this.setMargin.bind(this, opt.margin);
-          case 'jsPDF':
-            return function set_jsPDF() { this.opt.jsPDF = opt.jsPDF; return this.setPageSize(); }
-          case 'pageSize':
-            return this.setPageSize.bind(this, opt.pageSize);
-          default:
-            // Set any other properties in opt.
-            return function set_opt() { this.opt[key] = opt[key] };
+    switch (key) {
+      case 'margin':
+        return this.setMargin.bind(this, opt.margin);
+      case 'jsPDF':
+        return function set_jsPDF() { this.opt.jsPDF = opt.jsPDF; return this.setPageSize(); }
+      case 'pageSize':
+        return this.setPageSize.bind(this, opt.pageSize);
+      default:
+        if (key in Worker.template.prop) {
+          // Set pre-defined properties in prop.
+          return function set_prop() { this.prop[key] = opt[key]; }
+        } else {
+          // Set any other properties in opt.
+          return function set_opt() { this.opt[key] = opt[key] };
         }
-      }
+    }
   }, this);
 
   // Set properties within the promise chain.

--- a/test/settings.js
+++ b/test/settings.js
@@ -92,6 +92,14 @@ describe('settings', function () {
       return Math.floor(val * k / 72 * 96);
     }
 
+    it('set({ pageSize }) should call setPageSize', function () {
+      var worker = html2pdf();
+      chai.spy.on(worker, 'setPageSize', function () { return this.then(function () {}); });
+      return worker.set({ pageSize: 'test' }).then(function () {
+        expect(worker.setPageSize).to.have.been.called.with('test');
+        chai.spy.restore();
+      });
+    });
     it('setPageSize() with no argument should use jsPDF default settings', function () {
       var worker = html2pdf();
       return worker.setPageSize().get('pageSize').then(function (val) {


### PR DESCRIPTION
## This PR;

- fixes a bug where `set({ pageSize })` was directly setting `this.prop.pageSize`, rather than using `this.setPageSize` as intended
- adds a test to catch the bug
