### PR TITLE
Fix built assets to work when imported/required

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "html2pdf.js",
   "version": "0.10.0",
   "description": "Client-side HTML-to-PDF rendering using pure JS",
-  "main": "dist/require/html2pdf.cjs.js",
-  "module": "dist/include/html2pdf.es.js",
-  "browser": "dist/html2pdf.js",
+  "main": "dist/html2pdf.js",
   "files": [
     "/src",
     "/dist"

--- a/src/plugin/jspdf-plugin.js
+++ b/src/plugin/jspdf-plugin.js
@@ -1,5 +1,5 @@
 // Import dependencies.
-import jsPDF from 'jspdf';
+import { jsPDF } from 'jspdf';
 
 // Get dimensions of a PDF page, as determined by jsPDF.
 jsPDF.getPageSize = function(orientation, unit, format) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,5 +1,5 @@
-import jsPDF from 'jspdf';
-import html2canvas from 'html2canvas';
+import { jsPDF } from 'jspdf';
+import * as html2canvas from 'html2canvas';
 import { objType, createElement, cloneNode, toPx } from './utils.js';
 import es6promise from 'es6-promise';
 var Promise = es6promise.Promise;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = env => {
   const watch = isDev;
   const useAnalyzer = env.analyzer;
 
-  const makeBrowserConfig = (filename, { bundle, min } = {}) => ({
+  const makeUMDConfig = (filename, { bundle, min } = {}) => ({
     output: {
       filename,
       library: {
@@ -36,30 +36,12 @@ module.exports = env => {
     },
   });
 
-  const makeNodeConfig = (filename, { libraryTarget, target, externalsType, ...config }) => ({
-    output: {
-      filename,
-      libraryTarget,
-    },
-    target,
-    externals: externals,
-    externalsType,
-    babelOptions: {
-      presets: ['@babel/preset-env'],
-      targets: { node: "current" },
-    },
-    ...config,
-  });
-
-
   const builds = {
-    browser: makeBrowserConfig('html2pdf.js'),
-    browserBundle: makeBrowserConfig('html2pdf.bundle.js', { bundle: true }),
-    node: makeNodeConfig('require/html2pdf.cjs.js', { libraryTarget: 'commonjs2', target: 'node', externalsType: 'commonjs' }),
-    es: makeNodeConfig('include/html2pdf.es.js', { libraryTarget: 'module', target: 'es6', externalsType: 'module', experiments: { outputModule: true } }),
+    umd: makeUMDConfig('html2pdf.js'),
+    umdBundle: makeUMDConfig('html2pdf.bundle.js', { bundle: true }),
     ...(isDev ? {} : {
-      browserMin: makeBrowserConfig('html2pdf.min.js', { min: true }),
-      browserBundleMin: makeBrowserConfig('html2pdf.bundle.min.js', { bundle: true, min: true }),
+      umdMin: makeUMDConfig('html2pdf.min.js', { min: true }),
+      umdBundleMin: makeUMDConfig('html2pdf.bundle.min.js', { bundle: true, min: true }),
     }),
   };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const webpack = require('webpack');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const pkg = require('./package.json');
 
+const externals = [ 'jspdf', 'html2canvas' ];
 const banner = `${pkg.name} v${pkg.version}
 Copyright (c) ${(new Date).getFullYear()} Erik Koopmans
 Released under the ${pkg.license} License.`;
@@ -24,8 +25,8 @@ module.exports = env => {
       }
     },
     target: 'browserslist',
-    externals: bundle ? [] : ['jspdf', 'html2canvas'],
-    externalsType: 'global',
+    externals: bundle ? [] : externals,
+    externalsType: 'umd',
     optimization: { minimize: min },
     devtool: min ? 'source-map' : false,
     bundleAnalyzer: {
@@ -41,7 +42,7 @@ module.exports = env => {
       libraryTarget,
     },
     target,
-    externals: ['jspdf', 'html2canvas'],
+    externals: externals,
     externalsType,
     babelOptions: {
       presets: ['@babel/preset-env'],


### PR DESCRIPTION
## This PR:

- removes the `browser` and `module` fields of `package.json`, meaning all imports/requires will use the target of `main`
  - points `main` at `html2pdf.js`, which is bundled via UMD
  - removes the `.es` and `.cjs` built files, as they're no longer used
- fixes the externals of `html2pdf.js` to be loaded as UMD, which uses require where possible (e.g. Node) and falls back to the global namespace (e.g. when used directly in the browser)
- fixes some ambigous imports
  - this was causing issues when exporting to `module` in Webpack
  - the `module` export has now been removed, but the ambiguous import fix is still an improvement

Resolves #464

### Considerations

I have decided to consolidate all imports/requires to just the one dist file, `html2pdf.js`. This is in fact what most consumers of html2pdf.js have already been receiving, though unintentionally - modern bundlers use the `browser` field in `package.json` when creating a browser-targeted build (rather than my understanding, which was that `browser` was used only when importing *into* the browser).

The main thing we lose is the ES6-iness of the `.es` distributable (which is better for tree-shaking etc). In practice, this would only have previously been consumed by bundlers that were modern enough to consume the `module` field, but either not targeting the browser or not modern enough to recognize the `browser` field.

Ideally I would keep the `.es` dist and the `module` field, but that would be a change for anyone consuming the library, with potentially breaking behaviour. Specifically, it would break anyone using `require` with a bundler that supports ES, because of this inconsistency (in Webpack at least):

```js
import html2pdf from 'html2pdf.umd.js'
html2pdf()  // Works

import html2pdf from 'html2pdf.es.js'
html2pdf()  // Works

const html2pdf = require('html2pdf.umd.js')
html2pdf()  // Works

const html2pdf = require('html2pdf.es.js')
html2pdf()  // Doesn't work!! html2pdf is a Module, not a function
html2pdf.default()  // Works
```

So, I'm leaving it out! May revisit it later, which is why I've documented my findings here.

## Future improvements

- we will want integration tests to ensure that `html2pdf.js` is consistently imported into bundlers like Webpack/Rollup as well as when included directly in the browser as a `<script>`
  - this should test both `import` and `require`, as well as multiple targets (e.g. in Webpack, the `var` target etc)
