### PR TITLE
Update `outputPdf` documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The basic workflow of html2pdf.js tasks (enforced by the prereq system) is:
 | from         | src, type          | Sets the source (HTML string or element) for the PDF. Optional `type` specifies other sources: `'string'`, `'element'`, `'canvas'`, or `'img'`. |
 | to           | target             | Converts the source to the specified target (`'container'`, `'canvas'`, `'img'`, or `'pdf'`). Each target also has its own `toX` method that can be called directly: `toContainer()`, `toCanvas()`, `toImg()`, and `toPdf()`. |
 | output       | type, options, src | Routes to the appropriate `outputPdf` or `outputImg` method based on specified `src` (`'pdf'` (default) or `'img'`). |
-| outputPdf    | type, options      | Sends `type` and `options` to the jsPDF object's `output` method, and returns the result as a Promise (use `.then` to access). See the [jsPDF source code](https://rawgit.com/MrRio/jsPDF/master/docs/jspdf.js.html#line992) for more info. |
+| outputPdf    | type, options      | Sends `type` and `options` to the jsPDF object's `output` method, and returns the result as a Promise (use `.then` to access). See the [jsPDF documentation](https://rawgit.com/MrRio/jsPDF/master/docs/jsPDF.html#output) for more info. |
 | outputImg    | type, options      | Returns the specified data type for the image as a Promise (use `.then` to access). Supported types: `'img'`, `'datauristring'`/`'dataurlstring'`, and `'datauri'`/`'dataurl'`. |
 | save         | filename           | Saves the PDF object with the optional filename (creates user download prompt). |
 | set          | opt                | Sets the specified properties. See [Options](#options) below for more details. |


### PR DESCRIPTION
It appears the former link https://rawgit.com/MrRio/jsPDF/master/docs/jspdf.js.html#line992 has changed and looks confusing. 
We can use this one: https://rawgit.com/MrRio/jsPDF/master/docs/jsPDF.html#output