### PR TITLE
Fix ios pdf page limit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import Worker from './worker.js';
 import './plugin/jspdf-plugin.js';
 import './plugin/pagebreaks.js';
-import './plugin/hyperlinks.js';
 import './plugin/ios-pdf-fix.js';
+import './plugin/hyperlinks.js';
 
 /**
  * Generate a PDF from an HTML element or string using html2canvas and jsPDF.

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Worker from './worker.js';
 import './plugin/jspdf-plugin.js';
 import './plugin/pagebreaks.js';
 import './plugin/hyperlinks.js';
+import './plugin/ios-pdf-fix.js';
 
 /**
  * Generate a PDF from an HTML element or string using html2canvas and jsPDF.

--- a/src/plugin/ios-pdf-fix.js
+++ b/src/plugin/ios-pdf-fix.js
@@ -1,0 +1,53 @@
+import Worker from '../worker.js';
+import { jsPDF } from 'jspdf';
+import * as html2canvas from 'html2canvas';
+
+/* iOS PDF Canvas Size limitation Workaround plugin:
+
+    Creates a canvas per page instead of attempting to render the entire document as one canvas.
+    
+    This is not optimal but produces the desired result.
+*/
+
+Worker.prototype.toPdf = function toPdf() {
+  var prereqs = [
+    function checkContainer() { return document.body.contains(this.prop.container)
+                               || this.toContainer(); }
+  ];
+
+  return this.thenList(prereqs).then(async function toPdf_pagebreak_internal() {
+    var opt = this.opt;
+    var root = this.prop.container;
+    var pxPageWidth = this.prop.pageSize.inner.px.width;
+    var pxPageHeight = this.prop.pageSize.inner.px.height;
+
+    var clientBoundingRect = root.getBoundingClientRect();
+    
+    var pxFullHeight = clientBoundingRect.height;
+    var nPages = Math.ceil(pxFullHeight / pxPageHeight);
+    
+    opt.html2canvas.width = pxPageWidth;
+    opt.html2canvas.height = pxPageHeight;
+
+    // Initialize the PDF.
+    this.prop.pdf = this.prop.pdf || new jsPDF(opt.jsPDF);
+
+    for (var page=0; page<nPages; page++) {
+      var options = Object.assign({}, opt.html2canvas);
+      delete options.onrendered;
+
+      // Increase the y value to capture only the 'current' page
+      opt.html2canvas.y = (page + 1) * pxPageHeight;
+
+      var canvas = await html2canvas(this.prop.container, options);
+
+      // Add the page to the PDF.
+      if (page)  this.prop.pdf.addPage();
+      var imgData = canvas.toDataURL('image/' + opt.image.type, opt.image.quality);
+      this.prop.pdf.addImage(imgData, opt.image.type, opt.margin[1], opt.margin[0],
+        pxPageWidth, pxPageHeight);
+    }
+    
+    document.body.removeChild(this.prop.overlay);
+  });
+}

--- a/src/plugin/ios-pdf-fix.js
+++ b/src/plugin/ios-pdf-fix.js
@@ -29,6 +29,9 @@ Worker.prototype.toPdf = function toPdf() {
     opt.html2canvas.width = pxPageWidth;
     opt.html2canvas.height = pxPageHeight;
 
+    opt.html2canvas.windowWidth = pxPageWidth;
+    opt.html2canvas.windowHeight = pxPageHeight;
+
     // Initialize the PDF.
     this.prop.pdf = this.prop.pdf || new jsPDF(opt.jsPDF);
 
@@ -37,7 +40,8 @@ Worker.prototype.toPdf = function toPdf() {
       delete options.onrendered;
 
       // Increase the y value to capture only the 'current' page
-      opt.html2canvas.y = (page + 1) * pxPageHeight;
+      options.x = 0;
+      options.y = page * pxPageHeight;
 
       var canvas = await html2canvas(this.prop.container, options);
 
@@ -45,7 +49,7 @@ Worker.prototype.toPdf = function toPdf() {
       if (page)  this.prop.pdf.addPage();
       var imgData = canvas.toDataURL('image/' + opt.image.type, opt.image.quality);
       this.prop.pdf.addImage(imgData, opt.image.type, opt.margin[1], opt.margin[0],
-        pxPageWidth, pxPageHeight);
+                        this.prop.pageSize.inner.width, this.prop.pageSize.inner.height);
     }
     
     document.body.removeChild(this.prop.overlay);


### PR DESCRIPTION
Although this technically would help on any platform where exceeding browser imposed limit on the canvas resolution, this mostly only applies to the 5MP limit within modern iOS devices.

Let me know what you think.... I probably broke something somewhere for someone.