### PR TITLE
chore: Make a custom semantic-release action with build step

### DIFF
--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -1,0 +1,51 @@
+name: Semantic Release
+description: Deploy using semantic-release
+inputs:
+  DEFAULT_BRANCH:
+    description: Name of the default release branch
+    default: main
+  DRY_RUN:
+    description: Runs semantic-release with the "--dry-run" flag to simulate a release but not actually do one
+    default: false
+  GITHUB_TOKEN:
+    description: Token to use to update version in 'package.json' and create GitHub release
+    required: true
+  NPM:
+    description: Whether or not to release as an NPM package
+    default: false
+  NPM_TOKEN:
+    description: Token to publish to NPM (not required for CodeArtifact)
+outputs:
+  VERSION:
+    description: Version of the new release, or empty if release is unchanged
+    value: ${{ steps.semantic-release.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - name: Installing semantic-release
+      run: |
+        echo "Installing semantic-release..."
+        npm install semantic-release@19 @semantic-release/git@10 --no-save
+      shell: bash
+    - name: Run semantic-release
+      id: semantic-release
+      env:
+        DEFAULT_BRANCH: ${{ inputs.DEFAULT_BRANCH }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        NPM: ${{ inputs.NPM }}
+        NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
+      run: |
+        echo "version=" >> $GITHUB_OUTPUT
+        if [ ${{ inputs.DRY_RUN }} == true ]; then
+          echo "Running semantic-release (dry run)..."
+          npx semantic-release --dry-run -e ./.github/actions/semantic-release/release.config.js
+        else
+          OLD_VERSION=$(node -p -e "require('./package.json').version")
+          echo "Running semantic-release..."
+          npx semantic-release -e ./.github/actions/semantic-release/release.config.js
+          NEW_VERSION=$(node -p -e "require('./package.json').version")
+          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          fi
+        fi
+      shell: bash

--- a/.github/actions/semantic-release/release.config.js
+++ b/.github/actions/semantic-release/release.config.js
@@ -1,0 +1,27 @@
+const defaultBranch = process.env.DEFAULT_BRANCH || 'main';
+const npmPublish = process.env.NPM === 'true';
+
+module.exports = {
+  "branches": [
+    defaultBranch
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/github",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": npmPublish
+      }
+    ],
+    "./.github/actions/semantic-release/semantic-release.plugin.build.js",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["dist", "package.json", "package-lock.json"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]"
+      }
+    ]
+  ]
+};

--- a/.github/actions/semantic-release/semantic-release.plugin.build.js
+++ b/.github/actions/semantic-release/semantic-release.plugin.build.js
@@ -1,0 +1,7 @@
+const { execSync } = require('child_process');
+
+function prepare(pluginConfig, context) {
+  execSync('npm run build');
+}
+
+module.exports = { prepare };

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,8 @@ jobs:
           cache: npm
       - name: Install Dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
       - name: Semantic Release
-        uses: BrightspaceUI/actions/semantic-release@main
+        uses: ./.github/actions/semantic-release/
         with:
           GITHUB_TOKEN: ${{ steps.gh-token.outputs.token }}
           NPM: true

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "/src",
     "/dist"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/eKoopmans/html2pdf.js.git"
-  },
+  "repository": "git@github.com:eKoopmans/html2pdf.js.git",
   "keywords": [
     "javascript",
     "pdf-generation",


### PR DESCRIPTION
This PR should fix the semantic-release process to squeeze the build step in between when the NPM version is bumped and when the changes are committed and pushed.

The goal, in semantic-release:

1. [`commit-analyzer > analyzeCommits`](https://github.com/semantic-release/commit-analyzer) determines what kind of release to make
2. `semantic-release` internally determines the new package version based on that release info
3. ... other steps happen, e.g. `generateNotes`
4. [`npm > prepare`](https://github.com/semantic-release/npm) updates the package.json version
5. `semantic-release.plugin.build.js` (my new plugin) runs `npm run build`, generating a new `dist` folder
6. [`git > prepare`](https://github.com/semantic-release/git) creates the release commit with changes from dist and package*.json
7. ... other steps happen, e.g. npm publishing

In the future I'll be removing `dist` from git tracking, but regardless I want that build to happen in the middle so the bundle files can be generated with the right version and copyright etc.

### Resources:
- [BrightspaceUI/actions/semantic-release](https://github.com/BrightspaceUI/actions/tree/main/semantic-release)
- semantic-release [repo](https://github.com/semantic-release/semantic-release), [configuration](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md), [plugins](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/plugins.md) (plugin steps were useful)
    - there was pretty poor documentation about using local plugins and custom config file locations
- plugins in order of execution: [commit-analyzer](https://github.com/semantic-release/commit-analyzer), [github](https://github.com/semantic-release/github), [npm](https://github.com/semantic-release/npm), [release-notes-generator](https://github.com/semantic-release/release-notes-generator), [git](https://github.com/semantic-release/git)
- other existing semantic-release actions: https://github.com/codfish/semantic-release-action, https://github.com/cycjimmy/semantic-release-action
- plugin development: https://semantic-release.gitbook.io/semantic-release/developer-guide/plugin
- plugin steps:
  ```
  verifyConditions
	  github
	  npm
	  git
  analyzeCommits
	  commit-analyzer
  verifyRelease
  generateNotes
	  release-notes-generator
  prepare
	  npm
	  *MY BUILD PLUGIN*
	  git
  publish
	  github
	  npm
  addChannel
	  github
	  npm
  success
	  github
  fail
	  github
  ```