### PR TITLE
Fix pagebreaks when explicit width set

### DIFF
--- a/src/plugin/pagebreaks.js
+++ b/src/plugin/pagebreaks.js
@@ -41,6 +41,8 @@ Worker.prototype.toContainer = function toContainer() {
     // Setup root element and inner page height.
     var root = this.prop.container;
     var pxPageHeight = this.prop.pageSize.inner.px.height;
+    var ratio = this.prop.src.clientWidth / this.prop.pageSize.inner.px.width;
+    pxPageHeight *= ratio;
 
     // Check all requested modes.
     var modeSrc = [].concat(this.opt.pagebreak.mode);


### PR DESCRIPTION
Currently, setting an explicit width in the html2canvas options (e.g. `html2canvas: { width: 1000 }`) breaks the page height calculations in pagebreaks.js. This results in the overflow/gap calculation being wrong and an attempted pagebreak halfway through a page.

This short PR fixes the page height calculation.