### PR TITLE
fix: Add delay to ensure content is rendered before capturing

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -122,6 +122,8 @@ Worker.prototype.toContainer = function toContainer() {
     this.prop.container.appendChild(source);
     this.prop.overlay.appendChild(this.prop.container);
     document.body.appendChild(this.prop.overlay);
+
+    // Delay to better ensure content is fully cloned and rendering before capturing.
     return new Promise(resolve => setTimeout(resolve, 10));
   });
 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -122,6 +122,7 @@ Worker.prototype.toContainer = function toContainer() {
     this.prop.container.appendChild(source);
     this.prop.overlay.appendChild(this.prop.container);
     document.body.appendChild(this.prop.overlay);
+    return new Promise(resolve => setTimeout(resolve, 10));
   });
 };
 


### PR DESCRIPTION
This PR adds a small 10ms delay after cloning nodes, to improve the chances that the content is properly rendered before capturing with html2canvas. This isn't ideal (it'll make every call slower by 10ms and still doesn't guarantee anything), but should reduce flakiness.

This was impacting vdiffs and some local demos, which suggests that it may be a noticeable problem in prod as well. It was causing images to sometimes be cut off - the page height was calculated too small, since content wasn't fully rendered and hadn't reflowed to their final sizes.

---

A better solution would involve not cloning the content myself at all, and leaving window sizing etc to the image-capturing tool (html2canvas). There's a branch I created way back in 2019 to do just that:
https://github.com/eKoopmans/html2pdf.js/tree/bugfix/clone-nodes

Didn't want to jump straight to that solution though, because it'll introduce its own issues and will be a breaking change (no `toContainer` step etc).