### PR TITLE
Restore special token for release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,16 @@ jobs:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     steps:
+      - name: Create GH Token
+        uses: actions/create-github-app-token@v1
+        id: gh-token
+        with:
+          app-id: ${{ vars.GH_TOKEN_APP_ID }}
+          private-key: ${{ secrets.GH_TOKEN_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -20,6 +28,6 @@ jobs:
       - name: Semantic Release
         uses: ./.github/actions/semantic-release/
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.gh-token.outputs.token }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I thought I could just use GITHUB_TOKEN but the release failed, restoring the previous approach.