### PR TITLE
Upgrade jsPDF dependency from 3.0.0 to 3.0.2 to address DoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "html2canvas": "^1.0.0",
-        "jspdf": "^3.0.0"
+        "jspdf": "^3.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.14.8",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://ekoopmans.github.io/html2pdf.js/",
   "dependencies": {
     "html2canvas": "^1.0.0",
-    "jspdf": "^3.0.0"
+    "jspdf": "^3.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",


### PR DESCRIPTION
This pull request updates the jsPDF dependency from 3.0.0 to 3.0.2. The update resolves a high-severity denial‑of‑service vulnerability (CVE‑2025‑57810), where passing unsanitized or malformed PNG data to the addImage (and related methods like html) could trigger excessive CPU usage and hang the process. As of version 3.0.2, invalid image inputs now raise an error instead of causing prolonged loops or crashes.