### PR TITLE
fix:PDF export shows blank content when element uses position: absolute or position: fixed 

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -118,6 +118,14 @@ Worker.prototype.toContainer = function toContainer() {
 
     // Create and attach the elements.
     var source = deepCloneBasic(this.prop.src);
+    
+    // Force positioned element to static to avoid rendering issues
+    function resetPositioning(element) {
+      if (element.style) {
+        element.style.setProperty('position', 'static', 'important');
+      }
+    }
+    resetPositioning(source);
     this.prop.overlay = createElement('div',   { className: 'html2pdf__overlay', style: overlayCSS });
     this.prop.container = createElement('div', { className: 'html2pdf__container', style: containerCSS });
     this.prop.container.appendChild(source);


### PR DESCRIPTION
### Summary
Fix issue where exporting to PDF shows blank content when an element uses 
`position: absolute` or `position: fixed`.

### Problem
Currently, when an element is styled with `absolute` or `fixed` positioning, 
the generated PDF is empty. This happens because such elements are removed 
from the normal document flow and are not captured correctly.

### Solution
- Updated the rendering logic to properly include `absolute` and `fixed` 
  positioned elements during PDF export.
- Verified with test cases covering both absolute and fixed positioned nodes.

### How to Test
1. Create a div with `position: absolute` or `fixed`.
2. Trigger PDF export.
3. Verify the content is visible in the generated PDF.

### Related Issue
Closes #804
