### PR TITLE
fix: Include type file in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "./type.d.ts",
   "files": [
     "/src",
-    "/dist"
+    "/dist",
+    "./type.d.ts"
   ],
   "repository": "git@github.com:eKoopmans/html2pdf.js.git",
   "keywords": [


### PR DESCRIPTION
Adding the types file to npm `files` so that it gets correctly bundled.

Closes #812 
